### PR TITLE
Add missing response methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.swp
 *.pyc
+venv
+.venv
+mureq.iml

--- a/mureq.py
+++ b/mureq.py
@@ -189,14 +189,14 @@ class Response:
         return buf.getvalue()
 
     def raise_for_status(self):
-        """Raises :class:`HTTPError`, if one occurred."""
+        """Raises :class:`HTTPException`, if one occurred."""
 
         http_error_msg = ''
         if 400 <= self.status_code < 500:
-            http_error_msg = f'{self.status_code} Client Error for url: {self.url}'
+            http_error_msg = f'{self.status_code} - Client error for url: {self.url}'
 
         elif 500 <= self.status_code < 600:
-            http_error_msg = f'{self.status_code} Server Error for url: {self.url}'
+            http_error_msg = f'{self.status_code} - Server error for url: {self.url}'
 
         if http_error_msg:
             raise HTTPException(http_error_msg)

--- a/mureq.py
+++ b/mureq.py
@@ -202,7 +202,6 @@ class Response:
             raise HTTPException(http_error_msg)
 
     def json(self):
-        self.raise_for_status()
         return json.loads(self.body)
 
 

--- a/mureq.py
+++ b/mureq.py
@@ -8,6 +8,7 @@ mureq is copyright 2021 by its contributors and is released under the
 import contextlib
 import io
 import os.path
+import json
 import socket
 import ssl
 import sys
@@ -186,6 +187,23 @@ class Response:
         except UnicodeDecodeError:
             print("<%d bytes binary data>" % (len(self.body),), file=buf)
         return buf.getvalue()
+
+    def raise_for_status(self):
+        """Raises :class:`HTTPError`, if one occurred."""
+
+        http_error_msg = ''
+        if 400 <= self.status_code < 500:
+            http_error_msg = f'{self.status_code} Client Error for url: {self.url}'
+
+        elif 500 <= self.status_code < 600:
+            http_error_msg = f'{self.status_code} Server Error for url: {self.url}'
+
+        if http_error_msg:
+            raise HTTPException(http_error_msg)
+
+    def json(self):
+        self.raise_for_status()
+        return json.loads(self.body)
 
 
 class TooManyRedirects(HTTPException):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,4 +1,7 @@
+import json
 import unittest
+from http.client import HTTPException
+
 from mureq import _check_redirect, Response, HTTPMessage
 
 class RedirectTestCase(unittest.TestCase):
@@ -42,6 +45,28 @@ class ReponseTestCase(unittest.TestCase):
         self.assertEqual(Response('', 418, HTTPMessage(), b'').ok, False)
         self.assertEqual(Response('', 500, HTTPMessage(), b'').ok, False)
         self.assertEqual(Response('', 504, HTTPMessage(), b'').ok, False)
+
+    # noinspection PyMethodMayBeStatic
+    def test_raise_for_status_good(self):
+        resp = Response('', 201, HTTPMessage(), b"We're all OK")
+        resp.raise_for_status()
+
+    def test_raise_for_status_bad(self):
+        resp = Response('', 502, HTTPMessage(), b"It's going down")
+        with self.assertRaises(HTTPException):
+            resp.raise_for_status()
+
+    def test_json_good(self):
+        resp = Response('', 200, HTTPMessage(), b'{"data": 722}')
+        data = resp.json()
+
+        self.assertEqual(data['data'], 722)
+
+    def test_json_bad_response(self):
+        resp = Response('', 200, HTTPMessage(), b'THIS IS NOT JSON')
+
+        with self.assertRaises(json.decoder.JSONDecodeError):
+            resp.json()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some notable (and simple) Response object methods are missing:

- `Reponse.json()`
- `Reponse.raise_for_status()`

This PR adds those methods to the Response class.