### PR TITLE
Imports don't repeat, docs fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The core API (`mureq.get`, `mureq.post`, `mureq.request`, etc.) is similar to py
 If you're switching from python-requests, there are a few things to keep in mind:
 
 1. `mureq.get`, `mureq.post`, and `mureq.request` mostly work like the [analogous python-requests calls](https://docs.python-requests.org/en/latest/user/quickstart/#make-a-request).
-1. The response type is `mureq.HTTPResponse`, which exposes fewer methods and properties than `requests.Response`. In particular, it does not have `text` (since mureq doesn't do any encoding detection) or `json` (since mureq doesn't depend on the `json` package). Instead, the response body is in the `body` member, which is always of type `bytes`. (For the sake of compatibility, the `content` property is provided as an alias for `body`.)
+1. The response type is `mureq.HTTPResponse`, which exposes fewer methods and properties than `requests.Response`. In particular, it does not have `text` (since mureq doesn't do any encoding detection). Instead, the response body is in the `body` member, which is always of type `bytes`. (For the sake of compatibility, the `content` property is provided as an alias for `body`.)
 1. The default way to send a POST body is with the `body` kwarg, which only accepts `bytes`.
 1. The `json` kwarg takes an arbitrary object, which is serialized to JSON, encoded as UTF-8, and sent as the request body with the usual `Content-Type: application/json` header.
 1. To send a form-encoded POST body, use the `form` kwarg. This accepts a dictionary of key-value pairs, or any object that can be serialized by [urllib.parse.urlencode](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlencode). It will add the usual `Content-Type: application/x-www-form-urlencoded` header.

--- a/mureq.py
+++ b/mureq.py
@@ -187,7 +187,7 @@ class Response:
 
     def json(self):
         """Attempts to deserialize the response body as UTF-8 encoded JSON."""
-        _ensure_jsonlib()
+        import json as jsonlib
         return jsonlib.loads(self.body)
 
     def _debugstr(self):
@@ -227,17 +227,6 @@ class HTTPErrorStatus(HTTPException):
 
 _JSON_CONTENTTYPE = 'application/json'
 _FORM_CONTENTTYPE = 'application/x-www-form-urlencoded'
-
-jsonlib = None
-
-
-def _ensure_jsonlib():
-    global jsonlib
-    if jsonlib is None:
-        # to use simplejson exclusively, replace this with:
-        # import simplejson as json
-        import json
-        jsonlib = json
 
 
 class UnixHTTPConnection(HTTPConnection):
@@ -330,7 +319,7 @@ def _prepare_body(body, form, json, headers):
 
     if json is not None:
         _setdefault_header(headers, 'Content-Type', _JSON_CONTENTTYPE)
-        _ensure_jsonlib()
+        import json as jsonlib
         return jsonlib.dumps(json).encode('utf-8')
 
     if form is not None:


### PR DESCRIPTION
I found this cool project through PythonBytes (https://pythonbytes.fm/episodes/show/268/wait-you-can-google-that).

Just one little thing: There is no need to test if json has been imported already. Imports always only happen once. Just to be sure I made a little test:

If you have a module `module.py`:
```python
print("module being imported")
```

and a test file:
```python
def f1():
    import module as m
    print("inside f1")

def f2():
    import module as m
    print("inside f2")

f1()
f2()
```

the output is:

    module being imported
    inside f1
    inside f2

And the readme needed updating :-)