### PR TITLE
changes to incoming header processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ v0.3.0 is the third release of mureq.
 * Redirect handling of [303 See Other](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303) now clears the request body
 
 ### Added
-* Added `Response.raw_headers`, which contains the original unjoined headers as a list of string pairs
+* Added `Response.raw_headers`, which contains the original unjoined headers as an `http.client.HTTPMessage`. `raw_headers.get_all(header_name)` will retrieve a list of all repeated headers under `header_name`.
 * Added type annotations (thanks [@hbmartin](https://github.com/hbmartin)!)
 
 ## [0.2.0] - 2022-02-03

--- a/mureq.py
+++ b/mureq.py
@@ -49,8 +49,8 @@ def request(method: str, url: str, *, read_limit: int | None = None,  **kwargs) 
             raise
         except OSError as e:
             raise HTTPException(str(e)) from e
-        headers, raw_headers = _prepare_incoming_headers(response.headers)
-        return Response(response.url, response.status, headers, raw_headers, body)
+        headers = _prepare_incoming_headers(response.headers)
+        return Response(response.url, response.status, headers, response.headers, body)
 
 
 def get(url: str, **kwargs) -> "Response":
@@ -176,7 +176,7 @@ class Response:
     :ivar str url: the retrieved URL, indicating whether a redirection occurred
     :ivar int status_code: the HTTP status code
     :ivar http.client.HTTPMessage headers: the HTTP headers
-    :ivar raw_headers: the original unmerged HTTP headers as a list of tuples
+    :ivar http.client.HTTPMessage raw_headers: the original unmerged HTTP headers
     :ivar bytes body: the payload body of the response
     """
 
@@ -184,10 +184,10 @@ class Response:
     url: str
     status_code: int
     headers: Headers
-    raw_headers: list[tuple[str, str]]
+    raw_headers: Headers
     body: bytes
 
-    def __init__(self, url: str, status_code: int, headers: Headers, raw_headers: list[tuple[str, str]], body: bytes):
+    def __init__(self, url: str, status_code: int, headers: Headers, raw_headers: Headers, body: bytes):
         self.url, self.status_code, self.headers, self.raw_headers, self.body = \
             url, status_code, headers, raw_headers, body
 
@@ -321,18 +321,19 @@ def _prepare_outgoing_headers(headers: Headers | list[tuple[str, str]] | None) -
 
 # XXX join multi-headers together so that get(), __getitem__(),
 # etc. behave intuitively, then stuff them back in an HTTPMessage.
-def _prepare_incoming_headers(headers: HTTPMessage) -> tuple[HTTPMessage, list[tuple[str, str]]]:
-    raw_headers: list[tuple[str, str]] = []
+def _prepare_incoming_headers(headers: HTTPMessage) -> HTTPMessage:
+    header_to_name: dict[str, str] = {}
     headers_dict: dict[str, list[str]] = {}
     for k, v in headers.items():
-        headers_dict.setdefault(k, []).append(v)
-        raw_headers.append((k, v))
+        lower_name = k.lower()
+        header_to_name[lower_name] = k
+        headers_dict.setdefault(lower_name, []).append(v)
     result = HTTPMessage()
     # note that iterating over headers_dict preserves the original
     # insertion order in all versions since Python 3.6:
-    for k, vlist in headers_dict.items():
-        result[k] = ', '.join(vlist)
-    return result, raw_headers
+    for lower_name, vlist in headers_dict.items():
+        result[header_to_name[lower_name]] = ', '.join(vlist)
+    return result
 
 
 def _setdefault_header(headers, name, value):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -129,7 +129,7 @@ class MureqIntegrationTestCase(unittest.TestCase):
         self.assertTrue(date_header)
         # check raw_headers as well
         success = False
-        for k, v in response.raw_headers:
+        for k, v in response.raw_headers.items():
             if k.lower() == 'date':
                 success = True
                 self.assertEqual(v, date_header)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,5 +1,5 @@
 import unittest
-from mureq import _check_redirect, Response, HTTPMessage, HTTPErrorStatus
+from mureq import _check_redirect, _prepare_incoming_headers, Response, HTTPMessage, HTTPErrorStatus
 
 class RedirectTestCase(unittest.TestCase):
 
@@ -34,17 +34,17 @@ class RedirectTestCase(unittest.TestCase):
 class ReponseTestCase(unittest.TestCase):
 
     def test_ok(self):
-        self.assertEqual(Response('', 200, HTTPMessage(), [], b'').ok, True)
-        self.assertEqual(Response('', 204, HTTPMessage(), [], b'').ok, True)
-        self.assertEqual(Response('', 301, HTTPMessage(), [], b'').ok, True)
-        self.assertEqual(Response('', 400, HTTPMessage(), [], b'').ok, False)
-        self.assertEqual(Response('', 404, HTTPMessage(), [], b'').ok, False)
-        self.assertEqual(Response('', 418, HTTPMessage(), [], b'').ok, False)
-        self.assertEqual(Response('', 500, HTTPMessage(), [], b'').ok, False)
-        self.assertEqual(Response('', 504, HTTPMessage(), [], b'').ok, False)
+        self.assertEqual(Response('', 200, HTTPMessage(), HTTPMessage(), b'').ok, True)
+        self.assertEqual(Response('', 204, HTTPMessage(), HTTPMessage(), b'').ok, True)
+        self.assertEqual(Response('', 301, HTTPMessage(), HTTPMessage(), b'').ok, True)
+        self.assertEqual(Response('', 400, HTTPMessage(), HTTPMessage(), b'').ok, False)
+        self.assertEqual(Response('', 404, HTTPMessage(), HTTPMessage(), b'').ok, False)
+        self.assertEqual(Response('', 418, HTTPMessage(), HTTPMessage(), b'').ok, False)
+        self.assertEqual(Response('', 500, HTTPMessage(), HTTPMessage(), b'').ok, False)
+        self.assertEqual(Response('', 504, HTTPMessage(), HTTPMessage(), b'').ok, False)
 
     def _assert_raises_for_status(self, code):
-        resp = Response('', code, HTTPMessage(), [], b'')
+        resp = Response('', code, HTTPMessage(), HTTPMessage(), b'')
         try:
             resp.raise_for_status()
         except HTTPErrorStatus as e:
@@ -53,7 +53,7 @@ class ReponseTestCase(unittest.TestCase):
             raise AssertionError("did not raise for status", code)
 
     def _assert_does_not_raise_for_status(self, code):
-        resp = Response('', code, HTTPMessage(), [], b'')
+        resp = Response('', code, HTTPMessage(), HTTPMessage(), b'')
         resp.raise_for_status()
 
     def test_raise_for_status(self):
@@ -66,6 +66,77 @@ class ReponseTestCase(unittest.TestCase):
         self._assert_does_not_raise_for_status(204)
         self._assert_does_not_raise_for_status(301)
         self._assert_does_not_raise_for_status(307)
+
+
+def _make_message(*pairs):
+    """Build an HTTPMessage from (name, value) pairs, preserving duplicates."""
+    msg = HTTPMessage()
+    for k, v in pairs:
+        msg[k] = v
+    return msg
+
+
+class PrepareIncomingHeadersTestCase(unittest.TestCase):
+
+    def test_empty(self):
+        result = _prepare_incoming_headers(HTTPMessage())
+        self.assertEqual(list(result.items()), [])
+
+    def test_single_header(self):
+        msg = _make_message(('Content-Type', 'text/html'))
+        result = _prepare_incoming_headers(msg)
+        self.assertEqual(result['Content-Type'], 'text/html')
+        self.assertEqual(len(result.items()), 1)
+
+    def test_multiple_distinct_headers(self):
+        msg = _make_message(('Content-Type', 'text/html'), ('Content-Length', '42'))
+        result = _prepare_incoming_headers(msg)
+        self.assertEqual(result['Content-Type'], 'text/html')
+        self.assertEqual(result['Content-Length'], '42')
+        self.assertEqual(len(result.items()), 2)
+
+    def test_duplicate_headers_same_case_joined(self):
+        msg = _make_message(('Set-Cookie', 'a=1'), ('Set-Cookie', 'b=2'))
+        result = _prepare_incoming_headers(msg)
+        self.assertEqual(result['Set-Cookie'], 'a=1, b=2')
+        self.assertEqual(len(result.items()), 1)
+
+    def test_duplicate_headers_different_case_joined(self):
+        # Case-insensitive deduplication: both entries should be merged
+        msg = _make_message(('X-Custom', 'first'), ('x-custom', 'second'))
+        result = _prepare_incoming_headers(msg)
+        self.assertEqual(result['X-Custom'], 'first, second')
+        self.assertEqual(len(result.items()), 1)
+
+    def test_original_casing_preserved(self):
+        # When all occurrences share the same casing, that casing is preserved
+        msg = _make_message(('X-My-Header', 'v1'), ('X-My-Header', 'v2'))
+        result = _prepare_incoming_headers(msg)
+        keys = [k for k, _ in result.items()]
+        self.assertEqual(keys, ['X-My-Header'])
+
+    def test_three_duplicates_joined(self):
+        msg = _make_message(('Link', '<a>; rel=next'), ('Link', '<b>; rel=prev'), ('Link', '<c>; rel=first'))
+        result = _prepare_incoming_headers(msg)
+        self.assertEqual(result['Link'], '<a>; rel=next, <b>; rel=prev, <c>; rel=first')
+        self.assertEqual(len(result.items()), 1)
+
+    def test_insertion_order_preserved(self):
+        msg = _make_message(('Z-Header', 'z'), ('A-Header', 'a'), ('M-Header', 'm'))
+        result = _prepare_incoming_headers(msg)
+        keys = [k for k, _ in result.items()]
+        self.assertEqual(keys, ['Z-Header', 'A-Header', 'M-Header'])
+
+    def test_returns_httpmessage(self):
+        result = _prepare_incoming_headers(HTTPMessage())
+        self.assertIsInstance(result, HTTPMessage)
+
+    def test_lookup_is_case_insensitive(self):
+        # HTTPMessage supports case-insensitive lookup
+        msg = _make_message(('Content-Type', 'application/json'))
+        result = _prepare_incoming_headers(msg)
+        self.assertEqual(result['content-type'], 'application/json')
+        self.assertEqual(result['CONTENT-TYPE'], 'application/json')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Preserve the original HTTPMessage for the original headers
* Handle the server sending multi-headers with inconsistent casing (e.g. `Set-Cookie` and then `set-cookie`)